### PR TITLE
Add ficture segments (plain borders and dapi)

### DIFF
--- a/cellseg_benchmark/ficture_utils.py
+++ b/cellseg_benchmark/ficture_utils.py
@@ -386,7 +386,7 @@ def aggregate_tables(data_path: str, targets, gene_column: str = "gene",
         sdata.write(tmp, overwrite=True)
         sdata = sd.read_zarr(tmp)
         sopa.aggregate(sdata, gene_column=gene_column, aggregate_channels=False,
-                       min_transcripts=min_transcripts)
+                       min_transcripts=min_transcripts, shapes_key="boundaries")
         del sdata["transcripts"]
         sdata.write(str(zarr), overwrite=True)
         shutil.rmtree(tmp, ignore_errors=True)

--- a/cellseg_benchmark/ficture_utils.py
+++ b/cellseg_benchmark/ficture_utils.py
@@ -23,15 +23,12 @@ from tqdm import tqdm
 # workers (they re-import this module for _split_factor but never set the dask config).
 from cellseg_benchmark import _constants
 
-_F2CT = _constants.ficture_factor_to_celltype
-_TRUE = _constants.true_cluster
 _COLORS = _constants.cell_type_colors
-
-
-def _resolve_cell_type(factor: pd.Series) -> pd.Series:
-    """Map factor ids to their color-table cell-type names (see _constants.true_cluster)."""
-    resolve = lambda ct: (_TRUE.get(ct) or [ct])[0]
-    return factor.astype(str).map(_F2CT).map(resolve)
+# factor id (as str) -> color-table cell-type name (via _constants.true_cluster)
+_FACTOR_CELL_TYPE = {
+    f: (_constants.true_cluster.get(ct) or [ct])[0]
+    for f, ct in _constants.ficture_factor_to_celltype.items()
+}
 
 
 def parse_metadata(file_path: str) -> Dict[str, str]:
@@ -242,7 +239,7 @@ def segments_to_boundaries(lab: np.ndarray, affine: Affine) -> gpd.GeoDataFrame:
     gdf = gpd.GeoDataFrame(
         [{"factor": int(v) - 1, "geometry": shape(g)}
          for g, v in rf.shapes(lab, mask=lab > 0, transform=affine, connectivity=8)])
-    gdf["cell_type"] = _resolve_cell_type(gdf.factor)
+    gdf["cell_type"] = gdf.factor.astype(str).map(_FACTOR_CELL_TYPE)
     gdf["area_um2"] = gdf.geometry.area
     gdf.index.name = "segment_id"
     return gdf
@@ -331,7 +328,7 @@ def split_by_nuclei(lab: np.ndarray, affine: Affine, nuclei_xy, entity_ids,
          for g, v in rf.shapes(ws, mask=ws > 0, transform=affine, connectivity=8)]
     ).dissolve(by="cell_id", aggfunc={"factor": "first", "entity_id": "first",
                                       "n_nuclei": "first"})
-    gdf["cell_type"] = _resolve_cell_type(gdf.factor)
+    gdf["cell_type"] = gdf.factor.astype(str).map(_FACTOR_CELL_TYPE)
     gdf["area_um2"] = gdf.geometry.area
     return gdf
 

--- a/cellseg_benchmark/ficture_utils.py
+++ b/cellseg_benchmark/ficture_utils.py
@@ -305,9 +305,12 @@ def split_by_nuclei(lab: np.ndarray, affine: Affine, nuclei_xy, entity_ids,
 
     boxes = ndi.find_objects(lab)
     nuc_fac = lab[rows, cols]
-    tasks = [(int(fac), sl := boxes[fac - 1], lab[sl] == fac,
-              rows[nuc_fac == fac] - sl[0].start, cols[nuc_fac == fac] - sl[1].start,
-              ids[nuc_fac == fac]) for fac in np.unique(lab[lab > 0])]
+    tasks = []
+    for fac in np.unique(lab[lab > 0]):
+        sl = boxes[fac - 1]
+        sel = nuc_fac == fac
+        tasks.append((int(fac), sl, lab[sl] == fac,
+                      rows[sel] - sl[0].start, cols[sel] - sl[1].start, ids[sel]))
     results = Parallel(n_jobs=n_jobs, backend="loky")(
         delayed(_split_factor)(sub, rr, cc, ee, connectivity)
         for _, _, sub, rr, cc, ee in tasks)

--- a/cellseg_benchmark/ficture_utils.py
+++ b/cellseg_benchmark/ficture_utils.py
@@ -298,7 +298,7 @@ def split_by_nuclei(lab: np.ndarray, affine: Affine, nuclei_xy, entity_ids,
     rows = ((xy[:, 1] - offy) / res).astype(int)
     cols = ((xy[:, 0] - offx) / res).astype(int)
     inb = (rows >= 0) & (rows < lab.shape[0]) & (cols >= 0) & (cols < lab.shape[1])
-    if inb.mean() < 0.5:  # wrong frame -> most nuclei fall outside the raster
+    if inb.size and inb.mean() < 0.5:  # wrong frame -> most nuclei fall outside the raster
         raise ValueError(
             f"nuclei and pixel coordinate frames likely differ: only "
             f"{inb.mean():.0%} of nuclei fall within the raster")

--- a/cellseg_benchmark/ficture_utils.py
+++ b/cellseg_benchmark/ficture_utils.py
@@ -408,5 +408,5 @@ def plot_qc(gdf: gpd.GeoDataFrame, nuclei, aspect: float, title: str, path) -> N
     ax.set_aspect("equal")
     ax.axis("off")
     ax.set_title(title)
-    fig.savefig(str(path), dpi=300, bbox_inches="tight")
+    fig.savefig(str(path), dpi=400, bbox_inches="tight")
     plt.close(fig)

--- a/cellseg_benchmark/ficture_utils.py
+++ b/cellseg_benchmark/ficture_utils.py
@@ -216,7 +216,7 @@ def build_factor_raster(pixel_file: str, res: float = 1.5, min_um2: float = 5.0)
     lab = np.zeros((int(win.row.max()) + 1, int(win.col.max()) + 1), np.int32)
     lab[win.row, win.col] = win.K1 + 1
 
-    mp = max(1, int(min_um2 / res ** 2))     # drop tiny blobs / fill tiny holes
+    mp = max(1, int(min_um2 / res ** 2))
     clean = np.zeros_like(lab)
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=FutureWarning)
@@ -268,7 +268,7 @@ def _split_factor(sub, rr, cc, ee, conn):
                            mask=sub, connectivity=conn)
         out[lab_ws > 0] = lab_ws[lab_ws > 0]
     nid = len(metas) + 1
-    comp, ncomp = ndi.label(sub & (lab_ws == 0))   # nucleus-free components
+    comp, ncomp = ndi.label(sub & (lab_ws == 0))
     for k in range(1, ncomp + 1):
         out[comp == k] = nid
         metas.append((None, 0))
@@ -309,8 +309,8 @@ def split_by_nuclei(lab: np.ndarray, affine: Affine, bbox, nuclei_xy, entity_ids
     inb = (rows >= 0) & (rows < lab.shape[0]) & (cols >= 0) & (cols < lab.shape[1])
     rows, cols, ids = rows[inb], cols[inb], np.asarray(entity_ids)[inb]
 
-    boxes = ndi.find_objects(lab)          # bbox per factor -> small crops
-    nuc_fac = lab[rows, cols]              # factor(+1) under each nucleus
+    boxes = ndi.find_objects(lab)
+    nuc_fac = lab[rows, cols]
     tasks = [(int(fac), sl := boxes[fac - 1], lab[sl] == fac,
               rows[nuc_fac == fac] - sl[0].start, cols[nuc_fac == fac] - sl[1].start,
               ids[nuc_fac == fac]) for fac in np.unique(lab[lab > 0])]
@@ -318,7 +318,7 @@ def split_by_nuclei(lab: np.ndarray, affine: Affine, bbox, nuclei_xy, entity_ids
         delayed(_split_factor)(sub, rr, cc, ee, connectivity)
         for _, _, sub, rr, cc, ee in tasks)
 
-    ws = np.zeros_like(lab)                # global cell-id raster
+    ws = np.zeros_like(lab)
     factor, entity, nnuc = {}, {}, {}
     cid = 0
     for (fac, sl, *_), (out, metas) in zip(tasks, results):
@@ -370,9 +370,9 @@ def aggregate_tables(data_path: str, targets, gene_column: str = "gene",
     from spatialdata.models import ShapesModel
     from spatialdata.transformations import Identity, get_transformation
 
-    src = sopa.io.merscope(data_path)                      # images + transcripts (points)
+    src = sopa.io.merscope(data_path)
     tx = src[list(src.points.keys())[0]]
-    cs = list(get_transformation(tx, get_all=True).keys())  # coordinate system(s), in microns
+    cs = list(get_transformation(tx, get_all=True).keys())
 
     sopa.settings.parallelization_backend = "dask"
     sopa.settings.dask_client_kwargs["n_workers"] = n_workers
@@ -389,7 +389,7 @@ def aggregate_tables(data_path: str, targets, gene_column: str = "gene",
         sdata = sd.read_zarr(tmp)
         sopa.aggregate(sdata, gene_column=gene_column, aggregate_channels=False,
                        min_transcripts=min_transcripts)
-        del sdata["transcripts"]                            # keep boundaries + table only
+        del sdata["transcripts"]
         sdata.write(str(zarr), overwrite=True)
         shutil.rmtree(tmp, ignore_errors=True)
 

--- a/cellseg_benchmark/ficture_utils.py
+++ b/cellseg_benchmark/ficture_utils.py
@@ -201,9 +201,10 @@ def build_factor_raster(pixel_file: str, res: float = 1.5, min_um2: float = 5.0)
     meta = parse_metadata(pixel_file)
     offx, offy, scale = float(meta["OFFSET_X"]), float(meta["OFFSET_Y"]), float(meta["SCALE"])
     with gzip.open(pixel_file, "rt") as f:
-        cols = next(ln for ln in f if ln[:1] == "#" and ln[:2] != "##")[1:].strip().split("\t")
-
-    df = pd.read_csv(pixel_file, sep="\t", comment="#", names=cols, usecols=["X", "Y", "K1"])
+        for _ in range(3):
+            next(f)
+        cols = next(f).lstrip("#").strip().split("\t")
+    df = pd.read_csv(pixel_file, sep="\t", skiprows=4, names=cols, usecols=["X", "Y", "K1"])
     x, y = df.X / scale + offx, df.Y / scale + offy
     grid = pd.DataFrame({"row": ((y - offy) / res).astype(int),
                          "col": ((x - offx) / res).astype(int), "K1": df.K1})

--- a/cellseg_benchmark/ficture_utils.py
+++ b/cellseg_benchmark/ficture_utils.py
@@ -34,6 +34,24 @@ def _resolve_cell_type(factor: pd.Series) -> pd.Series:
     return factor.astype(str).map(_F2CT).map(resolve)
 
 
+def _patch_anndata_coo_to_csr():
+    """sopa 2.0.6 builds COO count matrices; anndata >=0.12 only accepts CSR/CSC."""
+    import anndata._core.anndata as core
+    import scipy.sparse as sp
+
+    if getattr(core, "_coo_to_csr_patched", False):
+        return
+    orig = core.coerce_array
+
+    def coerce_array(value, **kwargs):
+        if sp.issparse(value) and value.format not in ("csr", "csc"):
+            value = value.tocsr()
+        return orig(value, **kwargs)
+
+    core.coerce_array = coerce_array
+    core._coo_to_csr_patched = True
+
+
 def parse_metadata(file_path: str) -> Dict[str, str]:
     """Parse metadata from the first three lines of FICTURE pixel-level tsv.gz file.
 
@@ -368,6 +386,7 @@ def aggregate_tables(data_path: str, targets, gene_column: str = "gene",
     from spatialdata.models import ShapesModel
     from spatialdata.transformations import Identity, get_transformation
 
+    _patch_anndata_coo_to_csr()
     src = sopa.io.merscope(data_path)
     tx = src[list(src.points.keys())[0]]
     cs = list(get_transformation(tx, get_all=True).keys())

--- a/cellseg_benchmark/ficture_utils.py
+++ b/cellseg_benchmark/ficture_utils.py
@@ -276,7 +276,7 @@ def _split_factor(sub, rr, cc, ee, conn):
     return out, metas
 
 
-def split_by_nuclei(lab: np.ndarray, affine: Affine, bbox, nuclei_xy, entity_ids,
+def split_by_nuclei(lab: np.ndarray, affine: Affine, nuclei_xy, entity_ids,
                     connectivity: int = 1, n_jobs: int = 8) -> gpd.GeoDataFrame:
     """Split FICTURE segments into single cells using DAPI nuclei as seeds.
 
@@ -287,7 +287,6 @@ def split_by_nuclei(lab: np.ndarray, affine: Affine, bbox, nuclei_xy, entity_ids
     Args:
         lab: Majority-factor raster from build_factor_raster.
         affine: Grid->um transform (a/c/f give res, offset_x, offset_y).
-        bbox: (xmin, xmax, ymin, ymax) in um, for the frame-match check.
         nuclei_xy: (N, 2) nucleus centroids in um.
         entity_ids: (N,) nucleus ids aligned to nuclei_xy.
         connectivity: 1 (4-conn, avoids diagonal 1px bridges) or 2 (8-conn).
@@ -299,14 +298,13 @@ def split_by_nuclei(lab: np.ndarray, affine: Affine, bbox, nuclei_xy, entity_ids
     """
     res, offx, offy = affine.a, affine.c, affine.f
     xy = np.asarray(nuclei_xy, float)
-    nb = (xy[:, 0].min(), xy[:, 0].max(), xy[:, 1].min(), xy[:, 1].max())
-    tol = 0.05 * max(bbox[1] - bbox[0], bbox[3] - bbox[2])
-    if not all(abs(a - b) <= tol for a, b in zip(bbox, nb)):
-        raise ValueError(f"nuclei and pixel coordinate frames differ: pix{bbox} nuc{nb}")
-
     rows = ((xy[:, 1] - offy) / res).astype(int)
     cols = ((xy[:, 0] - offx) / res).astype(int)
     inb = (rows >= 0) & (rows < lab.shape[0]) & (cols >= 0) & (cols < lab.shape[1])
+    if inb.mean() < 0.5:  # wrong frame -> most nuclei fall outside the raster
+        raise ValueError(
+            f"nuclei and pixel coordinate frames likely differ: only "
+            f"{inb.mean():.0%} of nuclei fall within the raster")
     rows, cols, ids = rows[inb], cols[inb], np.asarray(entity_ids)[inb]
 
     boxes = ndi.find_objects(lab)

--- a/cellseg_benchmark/ficture_utils.py
+++ b/cellseg_benchmark/ficture_utils.py
@@ -397,7 +397,7 @@ def plot_qc(gdf: gpd.GeoDataFrame, nuclei, aspect: float, title: str, path) -> N
     gdf.plot(ax=ax, color=gdf.cell_type.map(_COLORS), edgecolor="black", linewidth=0.1)
     if nuclei is not None:
         ax.plot(nuclei[:, 0], nuclei[:, 1], "+", color="black",
-                markersize=0.9, markeredgewidth=0.2)
+                markersize=0.7, markeredgewidth=0.15)
     ax.set_aspect("equal")
     ax.axis("off")
     ax.set_title(title)

--- a/cellseg_benchmark/ficture_utils.py
+++ b/cellseg_benchmark/ficture_utils.py
@@ -1,13 +1,37 @@
 import gzip
+import shutil
+import warnings
 from typing import Dict
 
 import dask.dataframe as dd
+import geopandas as gpd
 import numpy as np
 import pandas as pd
+import rasterio.features as rf
 from dask.dataframe import DataFrame
+from joblib import Parallel, delayed
+from rasterio import Affine
+from scipy import ndimage as ndi
 from scipy.spatial import KDTree
-from spatialdata.models import PointsModel
+from shapely.geometry import shape
+from skimage.morphology import remove_small_holes, remove_small_objects
+from skimage.segmentation import watershed
 from tqdm import tqdm
+
+# NOTE: spatialdata is imported lazily inside the functions that need it. Importing
+# it at module top triggers spatialdata's dask-expr guard, which crashes joblib/loky
+# workers (they re-import this module for _split_factor but never set the dask config).
+from cellseg_benchmark import _constants
+
+_F2CT = _constants.ficture_factor_to_celltype
+_TRUE = _constants.true_cluster
+_COLORS = _constants.cell_type_colors
+
+
+def _resolve_cell_type(factor: pd.Series) -> pd.Series:
+    """Map factor ids to their color-table cell-type names (see _constants.true_cluster)."""
+    resolve = lambda ct: (_TRUE.get(ct) or [ct])[0]
+    return factor.astype(str).map(_F2CT).map(resolve)
 
 
 def parse_metadata(file_path: str) -> Dict[str, str]:
@@ -90,6 +114,8 @@ def get_pixel_level_factors(pixel_level_factors_file: str) -> DataFrame:
     Returns:
         PointsModel: Dask dataframe parsed  as a SpatialData PointsModel.
     """
+    from spatialdata.models import PointsModel
+
     metadata = parse_metadata(pixel_level_factors_file)
     df = load_pixel_tsv(pixel_level_factors_file, skiprows=3)
     dask_df = dd.from_pandas(process_coordinates(df, metadata), npartitions=96)
@@ -160,3 +186,225 @@ def create_factor_level_image(
     ).astype(np.uint16)  # makes smaller file
     image = image[np.newaxis, :]
     return image
+
+
+def build_factor_raster(pixel_file: str, res: float = 1.5, min_um2: float = 5.0):
+    """Rasterize a FICTURE pixel decode to a majority-factor grid.
+
+    Each grid cell stores its dominant factor + 1 (0 = background); tiny blobs
+    are dropped and tiny holes filled.
+
+    Args:
+        pixel_file: Path to decode.pixel.sorted.tsv.gz.
+        res: Grid size in micrometers.
+        min_um2: Minimum blob / maximum hole area in um^2.
+
+    Returns:
+        tuple: (label raster, affine px->um, (xmin, xmax, ymin, ymax) in um).
+    """
+    meta = parse_metadata(pixel_file)
+    offx, offy, scale = float(meta["OFFSET_X"]), float(meta["OFFSET_Y"]), float(meta["SCALE"])
+    with gzip.open(pixel_file, "rt") as f:
+        cols = next(l for l in f if l[:1] == "#" and l[:2] != "##")[1:].strip().split("\t")
+
+    df = pd.read_csv(pixel_file, sep="\t", comment="#", names=cols, usecols=["X", "Y", "K1"])
+    x, y = df.X / scale + offx, df.Y / scale + offy
+    grid = pd.DataFrame({"row": ((y - offy) / res).astype(int),
+                         "col": ((x - offx) / res).astype(int), "K1": df.K1})
+    counts = grid.groupby(["row", "col", "K1"]).size().reset_index(name="n")
+    win = counts.loc[counts.groupby(["row", "col"])["n"].idxmax()]
+    lab = np.zeros((int(win.row.max()) + 1, int(win.col.max()) + 1), np.int32)
+    lab[win.row, win.col] = win.K1 + 1
+
+    mp = max(1, int(min_um2 / res ** 2))     # drop tiny blobs / fill tiny holes
+    clean = np.zeros_like(lab)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=FutureWarning)
+        for fac in np.unique(lab[lab > 0]):
+            m = remove_small_holes(remove_small_objects(lab == fac, mp), area_threshold=mp)
+            clean[m & (clean == 0)] = fac
+
+    affine = Affine(res, 0, offx, 0, res, offy)
+    bbox = (float(x.min()), float(x.max()), float(y.min()), float(y.max()))
+    return clean, affine, bbox
+
+
+def segments_to_boundaries(lab: np.ndarray, affine: Affine) -> gpd.GeoDataFrame:
+    """Polygonize raw FICTURE segments (one polygon per connected same-factor patch).
+
+    Args:
+        lab: Majority-factor raster from build_factor_raster.
+        affine: Grid->um transform.
+
+    Returns:
+        GeoDataFrame indexed by segment_id with factor, cell_type, area_um2.
+    """
+    gdf = gpd.GeoDataFrame(
+        [{"factor": int(v) - 1, "geometry": shape(g)}
+         for g, v in rf.shapes(lab, mask=lab > 0, transform=affine, connectivity=8)])
+    gdf["cell_type"] = _resolve_cell_type(gdf.factor)
+    gdf["area_um2"] = gdf.geometry.area
+    gdf.index.name = "segment_id"
+    return gdf
+
+
+def _split_factor(sub, rr, cc, ee, conn):
+    """Split one factor crop into cells (module-level so joblib/loky can pickle it).
+
+    Each mask pixel is assigned to its nearest nucleus within the crop (geodesic
+    Voronoi = seeded watershed on a flat image); nucleus-free components are kept.
+
+    Returns:
+        tuple: (label crop with local ids, [(entity_id, n_nuclei) per local id]).
+    """
+    out = np.zeros(sub.shape, np.int32)
+    metas, lab_ws = [], np.zeros(sub.shape, np.int32)
+    if len(rr):
+        markers = np.zeros(sub.shape, np.int32)
+        for i, (r, c) in enumerate(zip(rr, cc), start=1):
+            markers[r, c] = i
+            metas.append((ee[i - 1], 1))
+        lab_ws = watershed(np.zeros(sub.shape, np.uint8), markers=markers,
+                           mask=sub, connectivity=conn)
+        out[lab_ws > 0] = lab_ws[lab_ws > 0]
+    nid = len(metas) + 1
+    comp, ncomp = ndi.label(sub & (lab_ws == 0))   # nucleus-free components
+    for k in range(1, ncomp + 1):
+        out[comp == k] = nid
+        metas.append((None, 0))
+        nid += 1
+    return out, metas
+
+
+def split_by_nuclei(lab: np.ndarray, affine: Affine, bbox, nuclei_xy, entity_ids,
+                    connectivity: int = 1, n_jobs: int = 8) -> gpd.GeoDataFrame:
+    """Split FICTURE segments into single cells using DAPI nuclei as seeds.
+
+    Each pixel is assigned to its nearest nucleus within its factor segment
+    (geodesic Voronoi); segments without a nucleus are kept and flagged
+    n_nuclei == 0. Factors are processed in parallel.
+
+    Args:
+        lab: Majority-factor raster from build_factor_raster.
+        affine: Grid->um transform (a/c/f give res, offset_x, offset_y).
+        bbox: (xmin, xmax, ymin, ymax) in um, for the frame-match check.
+        nuclei_xy: (N, 2) nucleus centroids in um.
+        entity_ids: (N,) nucleus ids aligned to nuclei_xy.
+        connectivity: 1 (4-conn, avoids diagonal 1px bridges) or 2 (8-conn).
+        n_jobs: Parallel workers.
+
+    Returns:
+        GeoDataFrame indexed by cell_id with factor, entity_id, n_nuclei,
+        cell_type, area_um2.
+    """
+    res, offx, offy = affine.a, affine.c, affine.f
+    xy = np.asarray(nuclei_xy, float)
+    nb = (xy[:, 0].min(), xy[:, 0].max(), xy[:, 1].min(), xy[:, 1].max())
+    tol = 0.05 * max(bbox[1] - bbox[0], bbox[3] - bbox[2])
+    if not all(abs(a - b) <= tol for a, b in zip(bbox, nb)):
+        raise ValueError(f"nuclei and pixel coordinate frames differ: pix{bbox} nuc{nb}")
+
+    rows = ((xy[:, 1] - offy) / res).astype(int)
+    cols = ((xy[:, 0] - offx) / res).astype(int)
+    inb = (rows >= 0) & (rows < lab.shape[0]) & (cols >= 0) & (cols < lab.shape[1])
+    rows, cols, ids = rows[inb], cols[inb], np.asarray(entity_ids)[inb]
+
+    boxes = ndi.find_objects(lab)          # bbox per factor -> small crops
+    nuc_fac = lab[rows, cols]              # factor(+1) under each nucleus
+    tasks = [(int(fac), sl := boxes[fac - 1], lab[sl] == fac,
+              rows[nuc_fac == fac] - sl[0].start, cols[nuc_fac == fac] - sl[1].start,
+              ids[nuc_fac == fac]) for fac in np.unique(lab[lab > 0])]
+    results = Parallel(n_jobs=n_jobs, backend="loky")(
+        delayed(_split_factor)(sub, rr, cc, ee, connectivity)
+        for _, _, sub, rr, cc, ee in tasks)
+
+    ws = np.zeros_like(lab)                # global cell-id raster
+    factor, entity, nnuc = {}, {}, {}
+    cid = 0
+    for (fac, sl, *_), (out, metas) in zip(tasks, results):
+        ws[sl][out > 0] = out[out > 0] + cid   # offset local ids -> global
+        for j, (e, nn) in enumerate(metas, start=1):
+            factor[cid + j], entity[cid + j], nnuc[cid + j] = fac - 1, e, nn
+        cid += len(metas)
+
+    gdf = gpd.GeoDataFrame(
+        [{"cell_id": int(v), "factor": factor[int(v)], "entity_id": entity[int(v)],
+          "n_nuclei": nnuc[int(v)], "geometry": shape(g)}
+         for g, v in rf.shapes(ws, mask=ws > 0, transform=affine, connectivity=8)]
+    ).dissolve(by="cell_id", aggfunc={"factor": "first", "entity_id": "first",
+                                      "n_nuclei": "first"})
+    gdf["cell_type"] = _resolve_cell_type(gdf.factor)
+    gdf["area_um2"] = gdf.geometry.area
+    return gdf
+
+
+def write_boundaries(gdf: gpd.GeoDataFrame, zarr) -> None:
+    """Write polygons as shapes["boundaries"] in a fresh SpatialData .zarr (Identity/micron)."""
+    import spatialdata as sd
+    from spatialdata.models import ShapesModel
+    from spatialdata.transformations import Identity
+
+    shapes = ShapesModel.parse(gdf, transformations={"micron": Identity()})
+    sd.SpatialData(shapes={"boundaries": shapes}).write(str(zarr), overwrite=True)
+
+
+def aggregate_tables(data_path: str, targets, gene_column: str = "gene",
+                     min_transcripts: int = 10, n_workers: int = 4) -> None:
+    """Assign MERSCOPE transcripts to boundary sets and write each as sdata with a table.
+
+    Loads the transcripts once (sopa.io.merscope) and aggregates counts per
+    polygon for every target (as in the repo's segmentation scripts). Each
+    output holds shapes["boundaries"] and the cell x gene AnnData under
+    tables["table"]; polygons below min_transcripts are dropped (shapes and
+    table stay consistent).
+
+    Args:
+        data_path: MERSCOPE output folder.
+        targets: iterable of (GeoDataFrame in um, output sdata.zarr path).
+        gene_column: Transcript gene column name.
+        min_transcripts: Minimum transcripts per polygon to keep.
+        n_workers: Dask workers for aggregation.
+    """
+    import sopa
+    import spatialdata as sd
+    from spatialdata.models import ShapesModel
+    from spatialdata.transformations import Identity, get_transformation
+
+    src = sopa.io.merscope(data_path)                      # images + transcripts (points)
+    tx = src[list(src.points.keys())[0]]
+    cs = list(get_transformation(tx, get_all=True).keys())  # coordinate system(s), in microns
+
+    sopa.settings.parallelization_backend = "dask"
+    sopa.settings.dask_client_kwargs["n_workers"] = n_workers
+    for gdf, zarr in targets:
+        sdata = sd.SpatialData(
+            points={"transcripts": tx},
+            shapes={"boundaries": ShapesModel.parse(
+                gdf, transformations={c: Identity() for c in cs})},
+        )
+        sdata.attrs["transcripts_dataframe"] = "transcripts"
+
+        tmp = f"{zarr}.tmp"                                 # sopa needs a backed store
+        sdata.write(tmp, overwrite=True)
+        sdata = sd.read_zarr(tmp)
+        sopa.aggregate(sdata, gene_column=gene_column, aggregate_channels=False,
+                       min_transcripts=min_transcripts)
+        del sdata["transcripts"]                            # keep boundaries + table only
+        sdata.write(str(zarr), overwrite=True)
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def plot_qc(gdf: gpd.GeoDataFrame, nuclei, aspect: float, title: str, path) -> None:
+    """Save a full-slide QC image: cells in cell-type colors, nuclei as short crosses."""
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots(figsize=(30, 30 * aspect))
+    gdf.plot(ax=ax, color=gdf.cell_type.map(_COLORS), edgecolor="black", linewidth=0.1)
+    if nuclei is not None:
+        ax.plot(nuclei[:, 0], nuclei[:, 1], "+", color="black",
+                markersize=0.9, markeredgewidth=0.2)
+    ax.set_aspect("equal")
+    ax.axis("off")
+    ax.set_title(title)
+    fig.savefig(str(path), dpi=300, bbox_inches="tight")
+    plt.close(fig)

--- a/cellseg_benchmark/ficture_utils.py
+++ b/cellseg_benchmark/ficture_utils.py
@@ -380,13 +380,15 @@ def aggregate_tables(data_path: str, targets, gene_column: str = "gene",
         sdata.attrs["transcripts_dataframe"] = "transcripts"
 
         tmp = f"{zarr}.tmp"                                 # sopa needs a backed store
-        sdata.write(tmp, overwrite=True)
-        sdata = sd.read_zarr(tmp)
-        sopa.aggregate(sdata, gene_column=gene_column, aggregate_channels=False,
-                       min_transcripts=min_transcripts, shapes_key="boundaries")
-        del sdata["transcripts"]
-        sdata.write(str(zarr), overwrite=True)
-        shutil.rmtree(tmp, ignore_errors=True)
+        try:
+            sdata.write(tmp, overwrite=True)
+            sdata = sd.read_zarr(tmp)
+            sopa.aggregate(sdata, gene_column=gene_column, aggregate_channels=False,
+                           min_transcripts=min_transcripts, shapes_key="boundaries")
+            del sdata["transcripts"]
+            sdata.write(str(zarr), overwrite=True)
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
 
 
 def plot_qc(gdf: gpd.GeoDataFrame, nuclei, aspect: float, title: str, path) -> None:

--- a/cellseg_benchmark/ficture_utils.py
+++ b/cellseg_benchmark/ficture_utils.py
@@ -18,9 +18,8 @@ from skimage.morphology import remove_small_holes, remove_small_objects
 from skimage.segmentation import watershed
 from tqdm import tqdm
 
-# NOTE: spatialdata is imported lazily inside the functions that need it. Importing
-# it at module top triggers spatialdata's dask-expr guard, which crashes joblib/loky
-# workers (they re-import this module for _split_factor but never set the dask config).
+# spatialdata is imported lazily inside functions; a module-top import trips its
+# dask-expr guard and crashes the joblib/loky workers.
 from cellseg_benchmark import _constants
 
 _COLORS = _constants.cell_type_colors

--- a/cellseg_benchmark/ficture_utils.py
+++ b/cellseg_benchmark/ficture_utils.py
@@ -201,7 +201,7 @@ def build_factor_raster(pixel_file: str, res: float = 1.5, min_um2: float = 5.0)
     meta = parse_metadata(pixel_file)
     offx, offy, scale = float(meta["OFFSET_X"]), float(meta["OFFSET_Y"]), float(meta["SCALE"])
     with gzip.open(pixel_file, "rt") as f:
-        cols = next(l for l in f if l[:1] == "#" and l[:2] != "##")[1:].strip().split("\t")
+        cols = next(ln for ln in f if ln[:1] == "#" and ln[:2] != "##")[1:].strip().split("\t")
 
     df = pd.read_csv(pixel_file, sep="\t", comment="#", names=cols, usecols=["X", "Y", "K1"])
     x, y = df.X / scale + offx, df.Y / scale + offy

--- a/cellseg_benchmark/ficture_utils.py
+++ b/cellseg_benchmark/ficture_utils.py
@@ -34,24 +34,6 @@ def _resolve_cell_type(factor: pd.Series) -> pd.Series:
     return factor.astype(str).map(_F2CT).map(resolve)
 
 
-def _patch_anndata_coo_to_csr():
-    """sopa 2.0.6 builds COO count matrices; anndata >=0.12 only accepts CSR/CSC."""
-    import anndata._core.anndata as core
-    import scipy.sparse as sp
-
-    if getattr(core, "_coo_to_csr_patched", False):
-        return
-    orig = core.coerce_array
-
-    def coerce_array(value, **kwargs):
-        if sp.issparse(value) and value.format not in ("csr", "csc"):
-            value = value.tocsr()
-        return orig(value, **kwargs)
-
-    core.coerce_array = coerce_array
-    core._coo_to_csr_patched = True
-
-
 def parse_metadata(file_path: str) -> Dict[str, str]:
     """Parse metadata from the first three lines of FICTURE pixel-level tsv.gz file.
 
@@ -381,12 +363,18 @@ def aggregate_tables(data_path: str, targets, gene_column: str = "gene",
         min_transcripts: Minimum transcripts per polygon to keep.
         n_workers: Dask workers for aggregation.
     """
+    import anndata._core.anndata as anndata_core
+    import scipy.sparse as sp
     import sopa
     import spatialdata as sd
     from spatialdata.models import ShapesModel
     from spatialdata.transformations import Identity, get_transformation
 
-    _patch_anndata_coo_to_csr()
+    # sopa 2.0.6 builds COO count matrices; anndata >=0.12 only accepts CSR/CSC
+    _coerce = anndata_core.coerce_array
+    anndata_core.coerce_array = lambda v, **kw: _coerce(
+        v.tocsr() if sp.issparse(v) and v.format not in ("csr", "csc") else v, **kw)
+
     src = sopa.io.merscope(data_path)
     tx = src[list(src.points.keys())[0]]
     cs = list(get_transformation(tx, get_all=True).keys())

--- a/cellseg_benchmark/ficture_utils.py
+++ b/cellseg_benchmark/ficture_utils.py
@@ -335,16 +335,6 @@ def split_by_nuclei(lab: np.ndarray, affine: Affine, nuclei_xy, entity_ids,
     return gdf
 
 
-def write_boundaries(gdf: gpd.GeoDataFrame, zarr) -> None:
-    """Write polygons as shapes["boundaries"] in a fresh SpatialData .zarr (Identity/micron)."""
-    import spatialdata as sd
-    from spatialdata.models import ShapesModel
-    from spatialdata.transformations import Identity
-
-    shapes = ShapesModel.parse(gdf, transformations={"micron": Identity()})
-    sd.SpatialData(shapes={"boundaries": shapes}).write(str(zarr), overwrite=True)
-
-
 def aggregate_tables(data_path: str, targets, gene_column: str = "gene",
                      min_transcripts: int = 10, n_workers: int = 4) -> None:
     """Assign MERSCOPE transcripts to boundary sets and write each as sdata with a table.

--- a/cellseg_benchmark/ficture_utils.py
+++ b/cellseg_benchmark/ficture_utils.py
@@ -364,7 +364,7 @@ def aggregate_tables(data_path: str, targets, gene_column: str = "gene",
     import sopa
     import spatialdata as sd
     from spatialdata.models import ShapesModel
-    from spatialdata.transformations import Identity, get_transformation
+    from spatialdata.transformations import get_transformation
 
     # sopa 2.0.6 builds COO count matrices; anndata >=0.12 only accepts CSR/CSC
     _coerce = anndata_core.coerce_array
@@ -373,15 +373,16 @@ def aggregate_tables(data_path: str, targets, gene_column: str = "gene",
 
     src = sopa.io.merscope(data_path)
     tx = src[list(src.points.keys())[0]]
-    cs = list(get_transformation(tx, get_all=True).keys())
+    # boundaries and transcript columns share the um frame -> give the boundaries the
+    # transcripts' transform so both map into "global" together
+    transforms = get_transformation(tx, get_all=True)
 
     sopa.settings.parallelization_backend = "dask"
     sopa.settings.dask_client_kwargs["n_workers"] = n_workers
     for gdf, zarr in targets:
         sdata = sd.SpatialData(
             points={"transcripts": tx},
-            shapes={"boundaries": ShapesModel.parse(
-                gdf, transformations={c: Identity() for c in cs})},
+            shapes={"boundaries": ShapesModel.parse(gdf, transformations=dict(transforms))},
         )
         sdata.attrs["transcripts_dataframe"] = "transcripts"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ spatialdata
 spatialdata-io>=0.1.5
 scanpy
 scikit-learn
+joblib
 scipy
 seaborn
 numpy
@@ -10,6 +11,7 @@ pandas
 shapely
 dask
 geopandas
+rasterio
 xarray
 tifffile
 tqdm

--- a/scripts/ficture/ficture_segments_to_sdata.py
+++ b/scripts/ficture/ficture_segments_to_sdata.py
@@ -44,6 +44,7 @@ log = logging.getLogger("ficture_segments")
 
 
 def main():
+    """Build FICTURE boundary sdatas (and transcript tables) for one sample."""
     p = argparse.ArgumentParser(description=__doc__,
                                 formatter_class=argparse.RawDescriptionHelpFormatter)
     p.add_argument("sample", help="sample id, e.g. foxf2_s7_r1")

--- a/scripts/ficture/ficture_segments_to_sdata.py
+++ b/scripts/ficture/ficture_segments_to_sdata.py
@@ -82,7 +82,7 @@ def main():
     log.info("[%s] loading nuclei and splitting", args.sample)
     obs = ad.read_zarr(str(dapi)).obs
     nuclei = obs[["center_x", "center_y"]].to_numpy(float)
-    cells = split_by_nuclei(lab, affine, bbox, nuclei, obs.index.to_numpy(),
+    cells = split_by_nuclei(lab, affine, nuclei, obs.index.to_numpy(),
                             args.connectivity, args.n_jobs)
     log.info("[%s] %d cells (%d nucleated, %d nucleus-free)", args.sample, len(cells),
              int((cells.n_nuclei == 1).sum()), int((cells.n_nuclei == 0).sum()))

--- a/scripts/ficture/ficture_segments_to_sdata.py
+++ b/scripts/ficture/ficture_segments_to_sdata.py
@@ -34,7 +34,6 @@ from cellseg_benchmark.ficture_utils import (  # noqa: E402
     plot_qc,
     segments_to_boundaries,
     split_by_nuclei,
-    write_boundaries,
 )
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
@@ -47,8 +46,8 @@ def main():
                                 formatter_class=argparse.RawDescriptionHelpFormatter)
     p.add_argument("sample", help="sample id, e.g. foxf2_s7_r1")
     p.add_argument("--base", default=_constants.BASE_PATH, help="cellseg-benchmark base path")
-    p.add_argument("--data-path", default=None,
-                   help="MERSCOPE output folder; if given, aggregate transcripts into a table")
+    p.add_argument("--data-path", required=True,
+                   help="MERSCOPE output folder (transcripts to aggregate into a table)")
     p.add_argument("--min-transcripts", type=int, default=10,
                    help="drop cells with fewer transcripts when building the table")
     p.add_argument("--res", type=float, default=1.5, help="grid size in um")
@@ -86,17 +85,13 @@ def main():
     log.info("[%s] %d cells (%d nucleated, %d nucleus-free)", args.sample, len(cells),
              int((cells.n_nuclei == 1).sum()), int((cells.n_nuclei == 0).sum()))
 
-    # write boundaries (+ transcript table if --data-path given)
+    # aggregate transcripts -> boundaries + table for both sets
     out_raw.mkdir(parents=True, exist_ok=True)
     out_split.mkdir(parents=True, exist_ok=True)
-    if args.data_path:
-        log.info("[%s] aggregating transcripts into tables", args.sample)
-        aggregate_tables(args.data_path,
-                         [(seg, out_raw / "sdata.zarr"), (cells, out_split / "sdata.zarr")],
-                         min_transcripts=args.min_transcripts, n_workers=args.n_jobs)
-    else:
-        write_boundaries(seg, out_raw / "sdata.zarr")
-        write_boundaries(cells, out_split / "sdata.zarr")
+    log.info("[%s] aggregating transcripts into tables", args.sample)
+    aggregate_tables(args.data_path,
+                     [(seg, out_raw / "sdata.zarr"), (cells, out_split / "sdata.zarr")],
+                     min_transcripts=args.min_transcripts, n_workers=args.n_jobs)
 
     # QC plots
     if not args.no_plot:

--- a/scripts/ficture/ficture_segments_to_sdata.py
+++ b/scripts/ficture/ficture_segments_to_sdata.py
@@ -12,7 +12,7 @@ in a ``sdata.zarr`` (polygons in micrometers, Identity transform to "micron"):
   within the segment. A segment with N nuclei becomes N cells; a segment with
   one nucleus stays whole; nucleus-free segments are kept (n_nuclei == 0).
 
-Logic lives in cellseg_benchmark.ficture_utils; this is the per-sample CLI:
+Per-sample CLI:
 
     python ficture_segments_to_sdata.py <SAMPLE_ID>
 """

--- a/scripts/ficture/ficture_segments_to_sdata.py
+++ b/scripts/ficture/ficture_segments_to_sdata.py
@@ -12,9 +12,7 @@ in a ``sdata.zarr`` (polygons in micrometers, Identity transform to "micron"):
   within the segment. A segment with N nuclei becomes N cells; a segment with
   one nucleus stays whole; nucleus-free segments are kept (n_nuclei == 0).
 
-The heavy lifting lives in cellseg_benchmark.ficture_utils; this script is just
-the per-sample CLI. Run (e.g. from an sbatch created by
-``ficture_segments_to_sdata_script_creation.py``)::
+Logic lives in cellseg_benchmark.ficture_utils; this is the per-sample CLI:
 
     python ficture_segments_to_sdata.py <SAMPLE_ID>
 """

--- a/scripts/ficture/ficture_segments_to_sdata.py
+++ b/scripts/ficture/ficture_segments_to_sdata.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+"""Turn a FICTURE pixel decode into cell boundaries as SpatialData objects.
+
+For one sample two boundary sets are written, each as ``shapes["boundaries"]``
+in a ``sdata.zarr`` (polygons in micrometers, Identity transform to "micron"):
+
+* ``Ficture_segments``       - raw FICTURE segments (one polygon per connected,
+  same-factor patch; neighbouring cells of one type stay fused).
+* ``Ficture_segments_dapi``  - the same segments split into single cells using
+  DAPI nuclei as seeds. A FICTURE segment carries no membrane, so its shape is
+  not a reliable border; instead every pixel is assigned to its nearest nucleus
+  within the segment. A segment with N nuclei becomes N cells; a segment with
+  one nucleus stays whole; nucleus-free segments are kept (n_nuclei == 0).
+
+The heavy lifting lives in cellseg_benchmark.ficture_utils; this script is just
+the per-sample CLI. Run (e.g. from an sbatch created by
+``ficture_segments_to_sdata_script_creation.py``)::
+
+    python ficture_segments_to_sdata.py <SAMPLE_ID>
+"""
+import argparse
+import logging
+import os
+from pathlib import Path
+
+import dask
+
+dask.config.set({"dataframe.query-planning": False})  # required before spatialdata import
+
+import anndata as ad  # noqa: E402
+
+from cellseg_benchmark import _constants  # noqa: E402
+from cellseg_benchmark.ficture_utils import (  # noqa: E402
+    aggregate_tables,
+    build_factor_raster,
+    plot_qc,
+    segments_to_boundaries,
+    split_by_nuclei,
+    write_boundaries,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("ficture_segments")
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("sample", help="sample id, e.g. foxf2_s7_r1")
+    p.add_argument("--base", default=_constants.BASE_PATH, help="cellseg-benchmark base path")
+    p.add_argument("--data-path", default=None,
+                   help="MERSCOPE output folder; if given, aggregate transcripts into a table")
+    p.add_argument("--min-transcripts", type=int, default=10,
+                   help="drop cells with fewer transcripts when building the table")
+    p.add_argument("--res", type=float, default=1.5, help="grid size in um")
+    p.add_argument("--min-um2", type=float, default=5.0, help="drop blobs / fill holes below this")
+    p.add_argument("--connectivity", type=int, default=1, choices=(1, 2),
+                   help="1 = 4-conn (avoids diagonal 1px bridges), 2 = 8-conn")
+    p.add_argument("--n-jobs", type=int,
+                   default=int(os.environ.get("SLURM_CPUS_PER_TASK")
+                               or os.environ.get("SLURM_CPUS_ON_NODE")
+                               or os.cpu_count() or 8),
+                   help="parallel workers (default: allocated SLURM cpus, else all cores)")
+    p.add_argument("--no-plot", action="store_true", help="skip QC plots")
+    args = p.parse_args()
+
+    root = Path(args.base) / "samples" / args.sample / "results"
+    pix = root / "Ficture" / "output" / "decode.pixel.sorted.tsv.gz"
+    dapi = root / "vpt_3D_DAPI_nuclei" / "sdata.zarr" / "tables" / "table"
+    out_raw = root / "Ficture_segments"
+    out_split = root / "Ficture_segments_dapi"
+
+    log.info("[%s] rasterizing FICTURE pixels (res=%s um)", args.sample, args.res)
+    lab, affine, bbox = build_factor_raster(str(pix), args.res, args.min_um2)
+    aspect = (bbox[3] - bbox[2]) / (bbox[1] - bbox[0])
+
+    # 1) raw FICTURE segments (fused patches)
+    seg = segments_to_boundaries(lab, affine)
+    log.info("[%s] %d unsplit segments", args.sample, len(seg))
+
+    # 2) nuclei-split cells
+    log.info("[%s] loading nuclei and splitting", args.sample)
+    obs = ad.read_zarr(str(dapi)).obs
+    nuclei = obs[["center_x", "center_y"]].to_numpy(float)
+    cells = split_by_nuclei(lab, affine, bbox, nuclei, obs.index.to_numpy(),
+                            args.connectivity, args.n_jobs)
+    log.info("[%s] %d cells (%d nucleated, %d nucleus-free)", args.sample, len(cells),
+             int((cells.n_nuclei == 1).sum()), int((cells.n_nuclei == 0).sum()))
+
+    # 3) write both boundary sets (with a transcript table if --data-path given)
+    out_raw.mkdir(parents=True, exist_ok=True)
+    out_split.mkdir(parents=True, exist_ok=True)
+    if args.data_path:   # assign transcripts -> tables["table"] on both sets
+        log.info("[%s] aggregating transcripts into tables", args.sample)
+        aggregate_tables(args.data_path,
+                         [(seg, out_raw / "sdata.zarr"), (cells, out_split / "sdata.zarr")],
+                         min_transcripts=args.min_transcripts, n_workers=args.n_jobs)
+    else:
+        write_boundaries(seg, out_raw / "sdata.zarr")
+        write_boundaries(cells, out_split / "sdata.zarr")
+
+    # 4) QC plots
+    if not args.no_plot:
+        plot_qc(seg, None, aspect, f"{args.sample}: FICTURE segments (unsplit)",
+                out_raw / "ficture_segments_qc.png")
+        plot_qc(cells, nuclei, aspect, f"{args.sample}: nuclei-split cells",
+                out_split / "ficture_segments_qc.png")
+    log.info("[%s] done", args.sample)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ficture/ficture_segments_to_sdata.py
+++ b/scripts/ficture/ficture_segments_to_sdata.py
@@ -74,11 +74,11 @@ def main():
     lab, affine, bbox = build_factor_raster(str(pix), args.res, args.min_um2)
     aspect = (bbox[3] - bbox[2]) / (bbox[1] - bbox[0])
 
-    # 1) raw FICTURE segments (fused patches)
+    # raw FICTURE segments
     seg = segments_to_boundaries(lab, affine)
     log.info("[%s] %d unsplit segments", args.sample, len(seg))
 
-    # 2) nuclei-split cells
+    # nuclei-split cells
     log.info("[%s] loading nuclei and splitting", args.sample)
     obs = ad.read_zarr(str(dapi)).obs
     nuclei = obs[["center_x", "center_y"]].to_numpy(float)
@@ -87,10 +87,10 @@ def main():
     log.info("[%s] %d cells (%d nucleated, %d nucleus-free)", args.sample, len(cells),
              int((cells.n_nuclei == 1).sum()), int((cells.n_nuclei == 0).sum()))
 
-    # 3) write both boundary sets (with a transcript table if --data-path given)
+    # write boundaries (+ transcript table if --data-path given)
     out_raw.mkdir(parents=True, exist_ok=True)
     out_split.mkdir(parents=True, exist_ok=True)
-    if args.data_path:   # assign transcripts -> tables["table"] on both sets
+    if args.data_path:
         log.info("[%s] aggregating transcripts into tables", args.sample)
         aggregate_tables(args.data_path,
                          [(seg, out_raw / "sdata.zarr"), (cells, out_split / "sdata.zarr")],
@@ -99,7 +99,7 @@ def main():
         write_boundaries(seg, out_raw / "sdata.zarr")
         write_boundaries(cells, out_split / "sdata.zarr")
 
-    # 4) QC plots
+    # QC plots
     if not args.no_plot:
         plot_qc(seg, None, aspect, f"{args.sample}: FICTURE segments (unsplit)",
                 out_raw / "ficture_segments_qc.png")

--- a/scripts/sbatch_utils/ficture_segments_to_sdata_script_creation.py
+++ b/scripts/sbatch_utils/ficture_segments_to_sdata_script_creation.py
@@ -12,7 +12,7 @@ import pathlib
 import yaml
 
 BASE_PATH = "/dss/dssfs03/pn52re/pn52re-dss-0001/cellseg-benchmark"
-CPUS = 16  # per-factor parallelism (exposed to the script as SLURM_CPUS_PER_TASK)
+CPUS = 16
 
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument("--res", type=float, default=1.5, help="grid size in um")

--- a/scripts/sbatch_utils/ficture_segments_to_sdata_script_creation.py
+++ b/scripts/sbatch_utils/ficture_segments_to_sdata_script_creation.py
@@ -42,3 +42,5 @@ mamba activate segmentation
 python ~/gitrepos/cellseg-benchmark/scripts/ficture/ficture_segments_to_sdata.py \\
  {key} --res {args.res} --data-path {value["path"]}
 """)
+
+print(f"Wrote {len(data)} sbatch scripts to {out_dir}")

--- a/scripts/sbatch_utils/ficture_segments_to_sdata_script_creation.py
+++ b/scripts/sbatch_utils/ficture_segments_to_sdata_script_creation.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+"""Create one SLURM job per sample to build FICTURE cell boundaries as sdatas.
+
+Each job runs scripts/ficture/ficture_segments_to_sdata.py, which writes the
+raw FICTURE segments (Ficture_segments) and the nuclei-split cells
+(Ficture_segments_dapi) as SpatialData .zarr objects, and aggregates MERSCOPE
+transcripts into a cell x gene table on the split cells.
+"""
+import argparse
+import pathlib
+
+import yaml
+
+BASE_PATH = "/dss/dssfs03/pn52re/pn52re-dss-0001/cellseg-benchmark"
+CPUS = 16  # per-factor parallelism (exposed to the script as SLURM_CPUS_PER_TASK)
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("--res", type=float, default=1.5, help="grid size in um")
+args = parser.parse_args()
+
+with open(f"{BASE_PATH}/misc/sample_metadata.yaml") as f:
+    data = yaml.safe_load(f)
+
+out_dir = pathlib.Path(f"{BASE_PATH}/misc/sbatches/sbatch_ficture_segments_to_sdata")
+out_dir.mkdir(parents=False, exist_ok=True)
+
+for key, value in data.items():
+    with open(out_dir / f"{key}.sbatch", "w") as f:
+        f.write(f"""#!/bin/bash
+
+#SBATCH -p lrz-cpu
+#SBATCH --qos=cpu
+#SBATCH -t 04:00:00
+#SBATCH --cpus-per-task={CPUS}
+#SBATCH --mem=128G
+#SBATCH -J ficture_segments_{key}
+#SBATCH -o {BASE_PATH}/misc/logs/outputs/ficture_segments_to_sdata_{key}.out
+#SBATCH -e {BASE_PATH}/misc/logs/errors/ficture_segments_to_sdata_{key}.err
+#SBATCH --container-image="{BASE_PATH}/misc/enroot_images/benchmark.sqsh"
+
+mamba activate segmentation
+python ~/gitrepos/cellseg-benchmark/scripts/ficture/ficture_segments_to_sdata.py \\
+ {key} --res {args.res} --data-path {value["path"]}
+""")

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,8 @@ setup(
         "shapely",
         "dask",
         "geopandas",
+        "rasterio",
+        "joblib",
         "xarray",
         "tifffile",
         "tqdm",


### PR DESCRIPTION
Adds a per-sample pipeline turning a FICTURE pixel decode into cell boundaries + transcript tables as SpatialData.

- `scripts/ficture/ficture_segments_to_sdata.py` — CLI per sample.
- `cellseg_benchmark/ficture_utils.py` — raster → segments, nuclei-seeded split, sopa aggregation, QC plot.
- `scripts/sbatch_utils/ficture_segments_to_sdata_script_creation.py` — per-sample sbatch generation.

Outputs two sdatas, each with `shapes["boundaries"]` + `tables["table"]`:
- `Ficture_segments` — raw FICTURE segments (fused same-factor patches).
- `Ficture_segments_dapi` — segments split into single cells via DAPI nuclei (geodesic Voronoi).

Deps: adds `rasterio`, `joblib`